### PR TITLE
More Robust lang, cleaned up layout

### DIFF
--- a/common/src/main/java/io/github/prismwork/emiffect/recipe/StatusEffectInfo.java
+++ b/common/src/main/java/io/github/prismwork/emiffect/recipe/StatusEffectInfo.java
@@ -91,7 +91,7 @@ public class StatusEffectInfo implements EmiRecipe {
         this.inputStackRow = inputs.isEmpty() ? 0 : 1;
         int inputColumn = 0;
         for (EmiIngredient ignored : inputs) {
-            if (inputColumn >= 6) {
+            if (inputColumn >= 8) {
                 this.inputStackRow += 1;
                 inputColumn = 0;
             }
@@ -120,6 +120,11 @@ public class StatusEffectInfo implements EmiRecipe {
     @Override
     public List<EmiStack> getOutputs() {
         return List.of(emiStack);
+    }
+
+    @Override
+    public boolean supportsRecipeTree() {
+        return false;
     }
 
     @Override
@@ -158,15 +163,15 @@ public class StatusEffectInfo implements EmiRecipe {
         int inputRow = 0;
         int inputColumn = 0;
         for (EmiIngredient ingredient : inputs) {
-            widgets.addSlot(ingredient, 18 + (inputColumn * 18), descHeight + 4 + (inputRow * 18));
+            widgets.addSlot(ingredient, (inputColumn * 18), descHeight + 4 + (inputRow * 18));
             inputColumn += 1;
-            if (inputColumn >= 6) {
+            if (inputColumn >= 8) {
                 inputRow += 1;
                 inputColumn = 0;
             }
         }
 
-        SlotWidget effectSlot = new SlotWidget(emiStack, 3, (descHeight - 26) / 2).large(true);
+        SlotWidget effectSlot = new SlotWidget(emiStack, 2, 14).large(true);
         widgets.add(effectSlot);
     }
 }

--- a/common/src/main/java/io/github/prismwork/emiffect/recipe/StatusEffectInfo.java
+++ b/common/src/main/java/io/github/prismwork/emiffect/recipe/StatusEffectInfo.java
@@ -15,6 +15,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.block.FlowerBlock;
 import net.minecraft.block.entity.BeaconBlockEntity;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.item.*;
@@ -22,6 +23,7 @@ import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionUtil;
 import net.minecraft.registry.Registries;
 import net.minecraft.text.OrderedText;
+import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Nullable;
@@ -40,6 +42,7 @@ public class StatusEffectInfo implements EmiRecipe {
     public StatusEffectInfo(StatusEffect effect, StatusEffectEmiStack emiStack) {
         this.id = Registries.STATUS_EFFECT.getId(effect) != null ? Registries.STATUS_EFFECT.getId(effect) : new Identifier("emiffect", "missingno");
         List<EmiIngredient> inputs0 = new ArrayList<>();
+
         for (Potion potion : Registries.POTION) {
             for (StatusEffectInstance instance : potion.getEffects()) {
                 if (instance.getEffectType().equals(effect)) {
@@ -79,8 +82,12 @@ public class StatusEffectInfo implements EmiRecipe {
                 inputs0.add(EmiStack.of(Blocks.BEACON));
             }
         }
+
         this.inputs = inputs0;
-        this.desc = MinecraftClient.getInstance().textRenderer.wrapLines(EmiPort.translatable("effect." + id.getNamespace() + "." + id.getPath() + ".description"), 110);
+        String key1 = "effect." + id.getNamespace() + "." + id.getPath() + ".description";
+        String key2 = "effect." + id.getNamespace() + "." + id.getPath() + ".desc";
+        Text description = I18n.hasTranslation(key1) ? EmiPort.translatable(key1) : (I18n.hasTranslation(key2) ? EmiPort.translatable(key2) : EmiPort.translatable("emiffect.status_effect_info.missing"));
+        this.desc = MinecraftClient.getInstance().textRenderer.wrapLines(description, 110);
         this.inputStackRow = inputs.isEmpty() ? 0 : 1;
         int inputColumn = 0;
         for (EmiIngredient ignored : inputs) {

--- a/common/src/main/java/io/github/prismwork/emiffect/util/stack/StatusEffectEmiStack.java
+++ b/common/src/main/java/io/github/prismwork/emiffect/util/stack/StatusEffectEmiStack.java
@@ -57,10 +57,10 @@ public class StatusEffectEmiStack extends EmiStack {
         StatusEffectSpriteManager sprites = MinecraftClient.getInstance().getStatusEffectSpriteManager();
         if (effect != null) {
             Sprite sprite = sprites.getSprite(effect);
-            RenderSystem.clearColor(1.0F, 1.0F,1.0F,1.0F);
+            RenderSystem.clearColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.setShader(GameRenderer::getPositionTexProgram);
             RenderSystem.setShaderTexture(0, sprite.getAtlasId());
-            draw.drawSprite(x, y, 0, 18, 18, sprite);
+            draw.drawSprite(x - 1, y - 1, 0, 18, 18, sprite);
             RenderSystem.applyModelViewMatrix();
         }
     }

--- a/common/src/main/java/io/github/prismwork/emiffect/util/stack/StatusEffectEmiStack.java
+++ b/common/src/main/java/io/github/prismwork/emiffect/util/stack/StatusEffectEmiStack.java
@@ -10,6 +10,10 @@ import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.StatusEffectSpriteManager;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.effect.DamageModifierStatusEffect;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.item.ItemStack;
@@ -25,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class StatusEffectEmiStack extends EmiStack {
     @Nullable
@@ -98,8 +103,48 @@ public class StatusEffectEmiStack extends EmiStack {
                     EmiPort.translatable("tooltip.emiffect.harmful").formatted(Formatting.RED))));
         }
         tooltips.add(TooltipComponent.of(EmiPort.ordered(
-                EmiPort.translatable("tooltip.emiffect.color", "#" + String.format("%02x", effect.getColor())).formatted(Formatting.GRAY))));
+                EmiPort.translatable("tooltip.emiffect.color", "#" + String.format("%02x", effect.getColor())).styled(style -> style.withColor(effect.getColor())))));
         Identifier id = Registries.STATUS_EFFECT.getId(effect);
+        if (!effect.getAttributeModifiers().isEmpty()) {
+            tooltips.add(TooltipComponent.of(EmiPort.ordered(EmiPort.literal(""))));
+            tooltips.add(TooltipComponent.of(EmiPort.ordered(EmiPort.translatable("tooltip.emiffect.applied").formatted(Formatting.GRAY))));
+            for (Map.Entry<EntityAttribute, EntityAttributeModifier> entry: effect.getAttributeModifiers().entrySet()) {
+                System.out.println(entry);
+                EntityAttributeModifier entityAttributeModifier = entry.getValue();
+                double d = entityAttributeModifier.getValue();
+                boolean damage = false;
+                if (effect instanceof DamageModifierStatusEffect damageModifierStatusEffect) {
+                    damage = true;
+                    d = damageModifierStatusEffect.adjustModifierAmount(0, entityAttributeModifier);
+                }
+                double e;
+                if (entityAttributeModifier.getOperation() != EntityAttributeModifier.Operation.MULTIPLY_BASE && entityAttributeModifier.getOperation() != EntityAttributeModifier.Operation.MULTIPLY_TOTAL) {
+                    if ((entry.getKey()).equals(EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE)) {
+                        e = d * 10.0;
+                    } else {
+                        e = d;
+                    }
+                } else {
+                    e = d * 100.0;
+                }
+
+                if (damage) {
+                    if (d > 0.0) {
+                        tooltips.add(TooltipComponent.of(EmiPort.ordered((EmiPort.translatable("attribute.modifier.plus." + entityAttributeModifier.getOperation().getId(), ItemStack.MODIFIER_FORMAT.format(e), Text.translatable((entry.getKey()).getTranslationKey())).formatted(Formatting.BLUE).append(EmiPort.translatable("tooltip.emiffect.per_level").formatted(Formatting.BLUE))))));
+                    } else if (d < 0.0) {
+                        e *= -1.0;
+                        tooltips.add(TooltipComponent.of(EmiPort.ordered((EmiPort.translatable("attribute.modifier.take." + entityAttributeModifier.getOperation().getId(), ItemStack.MODIFIER_FORMAT.format(e), Text.translatable((entry.getKey()).getTranslationKey())).formatted(Formatting.RED).append(EmiPort.translatable("tooltip.emiffect.per_level").formatted(Formatting.RED))))));
+                    }
+                } else {
+                    if (d > 0.0) {
+                        tooltips.add(TooltipComponent.of(EmiPort.ordered((EmiPort.translatable("attribute.modifier.plus." + entityAttributeModifier.getOperation().getId(), ItemStack.MODIFIER_FORMAT.format(e), Text.translatable((entry.getKey()).getTranslationKey())).formatted(Formatting.BLUE)))));
+                    } else if (d < 0.0) {
+                        e *= -1.0;
+                        tooltips.add(TooltipComponent.of(EmiPort.ordered((EmiPort.translatable("attribute.modifier.take." + entityAttributeModifier.getOperation().getId(), ItemStack.MODIFIER_FORMAT.format(e), Text.translatable((entry.getKey()).getTranslationKey())).formatted(Formatting.RED)))));
+                    }
+                }
+            }
+        }
         if (id != null)
             tooltips.add(TooltipComponent.of(EmiPort.ordered(EmiPort.literal(EmiUtil.getModName(id.getNamespace()), Formatting.BLUE, Formatting.ITALIC))));
         return tooltips;

--- a/common/src/main/resources/assets/emiffect/lang/en_us.json
+++ b/common/src/main/resources/assets/emiffect/lang/en_us.json
@@ -7,6 +7,8 @@
   "tooltip.emiffect.neutral": "Neutral",
   "tooltip.emiffect.harmful": "Harmful",
   "tooltip.emiffect.color": "Color: %s",
+  "tooltip.emiffect.applied": "While Active:",
+  "tooltip.emiffect.per_level": " per level",
 
   "effect.minecraft.absorption.description": "Adds damage some damaging absorbing hearths (which can't be regenerated); higher levels give more absorption.",
   "effect.minecraft.bad_omen.description": "Causes an illager raid to start upon entering a village; higher levels increase the raid difficulty.",

--- a/common/src/main/resources/assets/emiffect/lang/en_us.json
+++ b/common/src/main/resources/assets/emiffect/lang/en_us.json
@@ -1,6 +1,8 @@
 {
   "emi.category.emiffect.status_effect_info": "Status Effect Info",
 
+  "emiffect.status_effect_info.missing": "No description provided",
+
   "tooltip.emiffect.beneficial": "Beneficial",
   "tooltip.emiffect.neutral": "Neutral",
   "tooltip.emiffect.harmful": "Harmful",


### PR DESCRIPTION
* Both `.description` and `.desc` allowed now, with a No description provided fallback
* 8 columns of items, instead of 6, to use the space better
* aligned the input stack slot more consistently
* moved the rendering of the EmiStack by 1 up and left, to center it in frame